### PR TITLE
Contribute a Github Codespaces devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1
+
+# VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
+ARG VARIANT=hugo_extended
+# VERSION can be either 'latest' or a specific version number
+ARG VERSION=latest
+
+# Download and patch selected Hugo binary
+RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    case ${VERSION} in \
+    latest) \
+    export VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}') ;;\
+    esac && \
+    echo ${VERSION} && \
+    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-64bit.tar.gz && \
+    tar xf ${VERSION}.tar.gz && \
+    mv hugo* /usr/bin/hugo && \
+    go get github.com/yaegashi/muslstack && \
+    muslstack -s 0x800000 /usr/bin/hugo
+
+# Copy patched hugo binary from build stage
+FROM mcr.microsoft.com/vscode/devcontainers/base
+COPY --from=0 /usr/bin/hugo /usr/bin
+EXPOSE 1313
+
+# [Optional] Uncomment this section to install additional OS packages you may want.
+#
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/hugo
+{
+	"name": "WebRTCForTheCurious",
+
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update VERSION to pick a specific hugo version.
+			// Example versions: latest, 0.73.0, 0,71.1
+			// (Rebuild the container if it already exists to update.)
+			"VERSION": "latest",
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/zsh",
+		"markdownlint.config": {
+			// For what you can disable/enable here, see https://github.com/DavidAnson/markdownlint#rules--aliases
+			"default": true,
+			"no-trailing-punctuation": false,
+			"no-inline-html": false,
+			"first-line-h1": false,
+			"single-title": false
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"bungcip.better-toml",
+		"davidanson.vscode-markdownlint",
+		"editorconfig.editorconfig",
+		"usernamehw.errorlens",
+		"vstirbu.vscode-mermaid-preview",
+		"actboy168.tasks",
+		"github.vscode-pull-request-github",
+		"mhutchie.git-graph"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		1313
+	],
+	// (If you change port 1313 here, don't forget to edit the Dockerfile EXPOSE line.)
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// For example, to make sure our submodules are updated:
+	"postCreateCommand": "git submodule update --recursive --init",
+
+	// Connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root
+	"remoteUser": "vscode",
+
+	// Match UID and GID of above user to running host's user:
+	"updateRemoteUserUID": true
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs.
+
+# See https://editorconfig.org for more information.
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = false
+
+[Dockerfile]
+indent_style = space
+indent_size = 4
+
+[*.json]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 4
+
+[*.toml]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Live Docs Server (Hugo)",
+            "type": "shell",
+            "command": "hugo",
+            "args": ["server"],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "dedicated",
+                "showReuseMessage": false,
+                "clear": true
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "options": {
+                "statusbar": {
+                    "label":"$(book) Run Live Docs Server (Hugo)",
+                    "tooltip": "Click me to run Hugo to serve the book's site.",
+                    "color": "#22C1D6"
+                }
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ We would love contributions! We are open to suggestions about the content as wel
 |FAQ|Unstarted||[Edits](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious/edit/master/content//docs/10-faq.md) for content, Chapter [Ownership](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious/issues/10)|
 |Contributing|Unstarted||[Edits](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious/edit/master/content//docs/11-contributing.md) for content, Chapter [Ownership](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious/issues/10)|
 
+## Contributing from your browser (via Codespaces!)
+
+We support [*Github Codespaces*](https://github.com/features/codespaces) so helping out is as easy as starting up a Codespace from this repo.
+
+Once started, click "Run Live Docs Server" in the statusbar to start the Hugo server. Note that Hugo's autoreload doesn't trigger a browser refresh from Codespaces yet due to missing proxying of Websockets traffic. Reload a page manually to rerender it.
+
 # License
 
 This book is available under the CC0 license. The authors have waived all their copyright and related rights in their works to the fullest extent allowed by law. You May use this work however you want and no attribution is required.

--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -115,7 +115,7 @@ ice --> stun
 
 srtp --> rtcp
 srtp --> rtp
-{{< /mermaid >}}
+{{</mermaid>}}
 
 
 ## How does WebRTC (the API) work

--- a/content/docs/03-connecting.md
+++ b/content/docs/03-connecting.md
@@ -58,7 +58,7 @@ pub{Public Internet}
 routera-->pub
 routerb-->pub
 
-{{< /mermaid >}}
+{{</mermaid>}}
 
 For the hosts in the same network, it is very easy to connect. Communication between `192.168.0.1 -> 192.168.0.2` is easy to do! These two hosts can connect to each other without any outside help.
 
@@ -95,7 +95,7 @@ a1-.->routera;
 routera-.->pub;
 pub-.->routerb;
 routerb-.->b2;
-{{< /mermaid >}}
+{{</mermaid>}}
 
 To make this communication happen you establish a NAT Mapping. Creating a NAT mapping will feel like an automated/config-less version of doing port forwarding in your router.
 
@@ -274,7 +274,7 @@ serverport-->|"ChannelData (From UDP Client)"|turnclient
 
 peer-->|"Raw Network Traffic (To TURN Client)"|relayport
 relayport-->|"Raw Network Traffic (To UDP Client)"|peer
-{{< /mermaid >}}
+{{</mermaid>}}
 
 #### Two TURN Allocations for Communication
 {{<mermaid>}}
@@ -302,7 +302,7 @@ serverportB-->|"ChannelData"|turnclientB
 
 relayportA-->|"Raw Network Traffic"|relayportB
 relayportB-->|"Raw Network Traffic"|relayportA
-{{< /mermaid >}}
+{{</mermaid>}}
 
 ## ICE
 ICE (Interactive Connectivity Establishment) is how WebRTC connects two Agents. Defined in [RFC8445](https://tools.ietf.org/html/rfc8445), this is another technology that pre-dates WebRTC! ICE is a protocol for establishing connectivity. It determines all the possible routes between the two peers and then ensures you stay connected.
@@ -385,7 +385,7 @@ relayA --- hostB
 relayA --- serverreflexiveB
 relayA --- relayB
 linkStyle 6,7,8 stroke-width:2px,fill:none,stroke:blue;
-{{< /mermaid >}}
+{{</mermaid>}}
 
 ### Candidate Selection
 The Controlling and Controlled Agent both start sending traffic on each pair. This is needed if one Agent is behind a `Address Dependent Mapping`, this will cause a `Peer Reflexive Candidate` to be created.

--- a/content/docs/04-securing.md
+++ b/content/docs/04-securing.md
@@ -134,7 +134,7 @@ sequenceDiagram
     S->>C: ChangeCipherSpec
     S->>C: Finished
     Note over C,S: Flight 6
-{{< /mermaid >}}
+{{</mermaid>}}
 
 #### ClientHello
 ClientHello is the initial message sent by the client. It contains a list of attributes. These attributes tell the server the ciphers and features the client supports. For WebRTC this is how we choose the SRTP Cipher as well. It also contains random data that will be used to generate the keys for the session.


### PR DESCRIPTION
Hello!

I'm no WebRTC expert yet to help you with the missing chapters, but you core Pion devs were so nice in the #pion Slack with my noob questions lately that I felt compelled to contribute _something_ back in return. :smile:

* Firstly, I saw there wasn't [Codespaces](https://github.com/features/codespaces) support here and the README asks to install Hugo which is a few steps, so here is a `.devcontainer.json` and `Dockerfile` all preconfigured to go.

* Secondly, I also added an [EditorConfig file](https://editorconfig.org) to help contributors' IDEs keep consistent with basic stuff like tabulation and line endings.

* Thirdly, I added a `.vscode/tasks.json` to run "hugo server" to make it even easier to spawn Hugo from Codespaces/VSCode. This also lets the devcontainer.json's suggested VSCode extensions include [an extension](https://marketplace.visualstudio.com/items?itemName=actboy168.tasks) that lets you add the VSCode Task in the statusbar for convenient access:
![image](https://user-images.githubusercontent.com/941331/93659083-a3560b00-fa0f-11ea-9214-8251b122f1ea.png)

If there's anything you wish to change you may do so or tell me and I'll change it.

---

By the way, I noticed that Hugo's automatic browser refresh on autoreload does not happen. It detects file changes, yes, but **the browser does not autorefresh the page.**

Upon closer investigation this is not a bug with Hugo nor the configs, but a side effect of Github Codespaces **not presently supporting proxying of Websocket traffic** (which the [livereload.js](https://github.com/livereload/livereload-js) helper needs.) :man_shrugging:
