### PR TITLE
Build PDF via Pandoc on checkin

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,12 +7,16 @@ on:
 
 jobs:
   deploy:
+    name: Publish Website
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - run: |
+          echo "::set-env name=FILELIST::$(printf '"%s" ' content/docs/*.md)"
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -22,6 +26,10 @@ jobs:
 
       - name: Build
         run: hugo --minify
+          
+      - uses: docker://pandoc/latex:2.9
+        with:
+          args: --output=public/webrtc-for-the-curious.pdf ${{ env.FILELIST }}
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/content/_index.md
+++ b/content/_index.md
@@ -32,7 +32,7 @@ Each chapter doesn't assume prior knowledge. You can start at any point in the b
 
 ## Non-commercial and privacy-respecting
 
-This book is available on [GitHub](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious) and [WebRTCforTheCurious.com](https://webrtcforthecurious.com). It is licensed in a way that you can use it however you think is best.
+This book is available on [GitHub](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious) and [WebRTCforTheCurious.com](https://webrtcforthecurious.com). It is licensed in a way that you can use it however you think is best. If you prefer to download a PDF to read later, that can be found [here](https://webrtcforthecurious.com/webrtc-for-the-curious.pdf). 
 
 This book is written by individuals, for individuals. It is vendor agnostic so we will not make recommendations that could be a conflict of interest.
 


### PR DESCRIPTION
Adds steps to github action script to build a PDF version of the book using Pandoc and places it at the root of the site in webrtc-for-the-curious.pdf. Credit goes to @soolaugust from #27 for getting this started. 

You may want to consider where exactly you want the PDF to live. Right now it would be https://webrtcforthecurious.com/webrtc-for-the-curious.pdf but maybe you want a separate directory for downloads or something. 

With this PR, every time you accept a PR into master, it should automatically build the PDF and copy it into public, so if anything changes it should be updated in the next gh-pages commit.

Fixes #27. 