### PR TITLE
Add epub file creation to deploy script.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           args: --output=public/docs/webrtc-for-the-curious.pdf ${{ env.FILELIST }}
 
+      - uses: docker://pandoc/latex:2.9
+        with:
+          args: --output=public/docs/webrtc-for-the-curious.epub ${{ env.FILELIST }}
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/content/_index.md
+++ b/content/_index.md
@@ -32,7 +32,7 @@ Each chapter doesn't assume prior knowledge. You can start at any point in the b
 
 ## Non-commercial and privacy-respecting
 
-This book is available on [GitHub](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious) and [WebRTCforTheCurious.com](https://webrtcforthecurious.com). It is licensed in a way that you can use it however you think is best. If you prefer to download a PDF to read later, that can be found [here](https://webrtcforthecurious.com/docs/webrtc-for-the-curious.pdf).
+This book is available on [GitHub](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious) and [WebRTCforTheCurious.com](https://webrtcforthecurious.com). It is licensed in a way that you can use it however you think is best. You can also download the book in its current version as an [ePub](https://webrtcforthecurious.com/docs/webrtc-for-the-curious.epub) or [PDF](https://webrtcforthecurious.com/docs/webrtc-for-the-curious.pdf) file.
 
 This book is written by individuals, for individuals. It is vendor agnostic so we will not make recommendations that could be a conflict of interest.
 


### PR DESCRIPTION
Creates an ePub file the same way the PDF is created during deploying the website, places it in the docs folder. Also adds a link to the ePub file on the index page, next to the PDF link. 

Fixes #48.