### PR TITLE
Improve Pandoc Output, Mitigate CVE-2020-15228

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - run: |
-          echo "::set-env name=FILELIST::$(printf '"%s" ' content/docs/*.md)"
+          echo "FILELIST=\"content/_index.md\" $(printf '"%s" ' content/docs/*.md)" >> $GITHUB_ENV
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -29,11 +29,11 @@ jobs:
 
       - uses: docker://pandoc/latex:2.9
         with:
-          args: --output=public/docs/webrtc-for-the-curious.pdf ${{ env.FILELIST }}
+          args: --output=public/docs/webrtc-for-the-curious.pdf --toc ${{ env.FILELIST }} .pandoc/metadata_en.txt
 
       - uses: docker://pandoc/latex:2.9
         with:
-          args: --output=public/docs/webrtc-for-the-curious.epub ${{ env.FILELIST }}
+          args: --output=public/docs/webrtc-for-the-curious.epub --toc ${{ env.FILELIST }} .pandoc/metadata_en.txt
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.pandoc/metadata_en.txt
+++ b/.pandoc/metadata_en.txt
@@ -1,0 +1,6 @@
+---
+title: WebRTC For The Curious
+author: https://github.com/webrtc-for-the-curious/webrtc-for-the-curious
+rights: Creative Commons Zero v1.0 Universal
+language: en-US
+...

--- a/.pandoc/metadata_tr.txt
+++ b/.pandoc/metadata_tr.txt
@@ -1,0 +1,6 @@
+---
+title: WebRTC For The Curious -- TODO Translate to Turkish
+author: https://github.com/webrtc-for-the-curious/webrtc-for-the-curious
+rights: Creative Commons Zero v1.0 Universal
+language: tr
+...

--- a/content/docs/02-signaling.md
+++ b/content/docs/02-signaling.md
@@ -4,7 +4,7 @@ type: docs
 weight: 3
 ---
 
-## What is WebRTC Signaling?
+# What is WebRTC Signaling?
 When you create a WebRTC agent it knows nothing about the other peer. It has no idea who it is going to connect with or what they are going to send!
 Signaling is the initial bootstrapping that makes the call possible. After these values are exchanged the WebRTC agents then can communicate directly with each other.
 

--- a/content/docs/03-connecting.md
+++ b/content/docs/03-connecting.md
@@ -4,7 +4,7 @@ type: docs
 weight: 4
 ---
 
-## Why does WebRTC need a dedicated subsystem for connecting?
+# Why does WebRTC need a dedicated subsystem for connecting?
 
 WebRTC will go to great lengths to achieve direct bi-directional communication between two WebRTC Agents. This connection style is also known as peer-to-peer. Establishing peer-to-peer connectivity can be difficult though. These agents could be in different networks with no direct connectivity!
 

--- a/content/docs/04-securing.md
+++ b/content/docs/04-securing.md
@@ -5,7 +5,7 @@ weight: 5
 ---
 
 
-## What security does WebRTC have?
+# What security does WebRTC have?
 Every WebRTC connection is authenticated and encrypted. You can be confident that a 3rd party can't see what you are sending. They also can't insert bogus messages. You can also be sure the WebRTC Agent that generated the Session Description is the one you are communicating with.
 
 It is very important that no one tampers with those messages. It is ok if a 3rd party reads the Session Description in transit. However, WebRTC has no protection against it being modified. An attacker could MITM you by changing ICE Candidates and the Certificate Fingerprint.

--- a/content/docs/05-media-communication.md
+++ b/content/docs/05-media-communication.md
@@ -4,7 +4,7 @@ type: docs
 weight: 6
 ---
 
-## What do I get from WebRTC's media communication?
+# What do I get from WebRTC's media communication?
 WebRTC allows you to send and receive an unlimited amount of audio and video streams. You can add and remove these streams at anytime during a call. These streams could all be independent, or they could be bundled together! You could send a video feed of your desktop, and then include audio/video from your webcam.
 
 The WebRTC protocol is codec agnostic. The underlying transport supports everything, even things that don't exist yet! However, the WebRTC Agent you are communicating with may not have the necessary tools to accept it.

--- a/content/docs/06-data-communication.md
+++ b/content/docs/06-data-communication.md
@@ -4,7 +4,7 @@ type: docs
 weight: 7
 ---
 
-## What is Data Channel?
+# What is Data Channel?
 
 ### Questions From The Curious 
 I know many of you have a bunch of questions similar to the ones shown below.

--- a/content/docs/08-debugging.md
+++ b/content/docs/08-debugging.md
@@ -5,7 +5,7 @@ weight: 9
 ---
 
 
-## Debugging
+# Debugging
 Debugging WebRTC can be a daunting task. There are a lot of moving parts, and they all can break independently. If you aren't careful you can lose weeks of time looking at the wrong things. When you do finally find the part that is broken you will need to learn a bit to understand it.
 
 This chapter will get you in the mindset to debug WebRTC. It will show you how to break down the problem. After we know the problem we will give a quick tour of the popular debugging tools. 

--- a/content/docs/11-contributing.md
+++ b/content/docs/11-contributing.md
@@ -4,4 +4,4 @@ type: docs
 weight: 12
 ---
 
-## Contributing
+# Contributing


### PR DESCRIPTION
Github Actions is now throwing a warning anytime you use the set-env command due to [CVE-2020-15228](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). This PR mitigates the use of set-env by using the new $GITHUB_ENV variable. 

While I was cleaning that up, I also took a look at the PDF as it is generated now, compared to the website. I had neglected to include the index file in the first version, and the table of contents was all sorts of funky because not every Chapter started with a level-1 heading, which is what Pandoc is looking for. Well, technically it is looking for consistency, and the mix of level-1 and level-2 headings makes that not possible. 

The PDF/ebook metadata also is now filled in appropriately. Whereas before it was taking the last file's title as the overall title (Contributing), now it reads the metadata file last and correctly sets those values.