### PR TITLE
Update 05-media-communication.md

### DIFF
--- a/content/docs/05-media-communication.md
+++ b/content/docs/05-media-communication.md
@@ -14,15 +14,15 @@ WebRTC is also designed to handle dynamic network conditions. During a call your
 ## How does it work?
 WebRTC uses two pre-existing protocols RTP and RTCP, both defined in [RFC 1889](https://tools.ietf.org/html/rfc1889)
 
-RTP is the protocol that carries the media. It was designed to allow real-time delivery of video. It doesn't stipulate any rules around latency or reliability, but gives you the tools to implement them. RTP gives you streams, so you can run multiple media feeds over one connection. It also gives you the timing and ordering information you need to feed a media pipeline.
+RTP (Real-time Transport Protocol) is the protocol that carries the media. It was designed to allow for real-time delivery of video. It does not stipulate any rules around latency or reliability, but gives you the tools to implement them. RTP gives you streams, so you can run multiple media feeds over one connection. It also gives you the timing and ordering information you need to feed a media pipeline.
 
-RTCP is the protocol that communicates metadata about the call. The format is flexible enough so you can add whatever you want. This is used to communicate statistics about the call. It is also necessary to handle packet loss and to implement congestion control. It gives you the bi-directional communication necessary to respond to network conditions changing.
+RTCP (RTP Control Protocol) is the protocol that communicates metadata about the call. The format is very flexible and allows you to add any metadata you want. This is used to communicate statistics about the call. It is also used to handle packet loss and to implement congestion control. It gives you the bi-directional communication necessary to respond to changing network conditions.
 
 ## Latency vs Quality
 Real-time media is about making trade-offs between latency and quality. The more latency you are willing to tolerate, the higher quality video you can expect.
 
 ### Real World Limitations
-These constraints are all caused by the limitations of the real world. These are all characteristics of your network that you will need to overcome.
+These constraints are all caused by the limitations of the real world. They are all characteristics of your network that you will need to overcome.
 
 #### Bandwidth
 Bandwidth is the maximum rate of data that can be transferred across a given path. It is important to remember this isn't a static number either. The bandwidth will change along the route as more (or less) people use it.
@@ -36,12 +36,12 @@ Transmission Time is how long it takes for a packet to arrive. Like Bandwidth th
 Jitter is the fact that `Transmission Time` may vary. Some times you will see packets arrive in bursts. Any piece of hardware along the network path can introduce issues.
 
 #### Packet Loss
-Packet Loss is when messages are lost in transmission. The loss could be steady, or it could come in spikes. This isn't an uncommon occurrence either!
+Packet Loss is when messages are lost in transmission. The loss could be steady, or it could come in spikes. This is also a common issue, especially on wireless networks!
 
 #### Maximum transmission unit
-Maximum Transmission Unit is the limit on how large a single packet can be. Networks don't allow you to send one giant message. At the protocol level you need to packetize your data into small packets.
+Maximum Transmission Unit is the limit on how large a single packet can be. Networks don't allow you to send one giant message. At the protocol level, you need to split your data into multiple small packets.
 
-The MTU will also differ depending on what network path you take. You can use a protocol like [Path MTU Discovery](https://tools.ietf.org/html/rfc1191) to figure out what the largest packet size is you can send.
+The MTU will also differ depending on what network path you take. You can use a protocol like [Path MTU Discovery](https://tools.ietf.org/html/rfc1191) to figure out the largest packet size you can send.
 
 ## Media 101
 ### Codec
@@ -74,8 +74,7 @@ Every RTP packet has the following structure:
 #### Padding (P)
 `Padding` is a bool that controls if the payload has padding.
 
-The last byte of the payload contains a count of how many padding bytes
-were added.
+The last byte of the payload contains a count of how many padding bytes were added.
 
 #### Extension (X)
 If set the RTP header will have extensions. This is described in greater detail below.
@@ -108,6 +107,9 @@ A `SSRC` is the unique identifier for this stream. This allows you to run multip
 A list that communicates what `SSRC`es contributed to this packet.
 
 This is commonly used for talking indicators. Lets say server side you combined multiple audio feeds into a single RTP stream. You could then use this field to say 'Input stream A and C were talking at this moment'
+
+#### Payload
+The actual payload data. Might end with the count of how many padding bytes were added, if the padding flag is set.
 
 ### Extensions
 
@@ -164,7 +166,7 @@ NACKs are much more bandwidth efficent then requesting that the whole frame get 
 ### Sender/Receiver Reports
 These reports are used to send statistics between agents. This communicates the amount of packets actually received and jitter.
 
-The reports could be used for general or diagnostics, or basic Congestion Control.
+The reports can be used for diagnostics or basic Congestion Control.
 
 ### Generic RTP Feedback
 
@@ -179,90 +181,87 @@ A NACK is a RTCP message sent back to a sender to request re-transmission. The r
 ### Forward Error Correction
 Also known as FEC. Another method of dealing with packet loss. FEC is when you send the same data multiple times, without it even being requested. This be done at the RTP level, or even lower with the codec.
 
-If the packet loss for a call is steady this is much better then NACKs. The round trip of having to request, and then re-transmit the packet can be significant for NACKs.
+If the packet loss for a call is steady, this is much better then NACKs. The round trip of having to request and then re-transmit a packet can be significant for NACKs.
 
 ### Adaptive bitrate and Bandwidth Estimation
 
-A common problem of modern IP networks both wireless and wired is unpredictable and unreliable available bandwidth. Network conditions are changing dynamically multiple times throughout a session, it is not uncommon to see available bandwidth change drammatically (orders of magnitude) within a second.
+A common problem of modern IP networks, both wireless and wired, is unpredictable and unreliable bandwidth. Network conditions are changing dynamically multiple times throughout a session. It is not uncommon to see available bandwidth change drammatically (orders of magnitude) within a second.
 
-Wired networks' intrinsics unpredictability is caused by changing demand for bandwidth shared across multiple users of the network, routing changes, limitations of transfer medium (fiber channel vs ethernet vs dsl) etc.
-In addition to wired networks' issues the nature of radio signal transmission itself, interference from multiple sources, distance to cell tower or wifi access point and amount of physical obstacles (read walls) are among the reasons for unpredictable wireless network characteristics.
+Unpredictability in wired networks can be caused by changing demand for bandwidth across the network, routing changes, limitations of transfer medium (fiber channel vs ethernet vs dsl) and more.
 
-WebRTC has several mechanisms to help deliver video/audio signal to receiver despite changing network conditions.
-The main idea is to adjust encoding bitrate based on predicted current and future available network bandwidth.
-This ensures that video/audio signal of the best possible quality is transmitted and connection does not get dropped because of network congestion.
-Heuristics that model the network behavior and try to predict it are known as Bandwidth estimation.
+In addition to issues seen in wired networks, the nature of radio signal transmission itself, interference from multiple sources, distance to cell towers or Wi-Fi access points and physical obstacles (read walls) are some reasons for unpredictable wireless network characteristics.
+
+WebRTC has several mechanisms to help deliver video/audio signals to the receiver despite changing network conditions.
+The main idea is to adjust encoding bitrate based on predicted, current, and future available network bandwidth.
+This ensures that video/audio signal of the best possible quality is transmitted and the connection does not get dropped because of network congestion.
+Heuristics that model the network behavior and tries to predict it is known as Bandwidth estimation.
 
 #### REMB
 
 A widely supported albeit never fully standardized and now considered deprecated method is called [REMB](https://tools.ietf.org/html/draft-alvestrand-rmcat-remb-03) (Receiver Estimated Maximum Bitrate).
-REMB is a special RTCP packet receiver sends to sender notifying the sender of available bandwidth. There's no(?) standard on the method used to estimate bandwidth associated with REMB, so the actual values are implementation dependent. Good starting point for research into details or REMB is [Chrome's source code](https://source.chromium.org/chromium/chromium/src/+/master:third_party/webrtc/modules/rtp_rtcp/source/rtcp_packet/remb.cc)
+REMB is a special RTCP packet the receiver sends to the sender, notifying the sender of available bandwidth. There is no(?) standard method defined to estimate bandwidth associated with REMB, so the actual values are implementation dependent. A good starting point for research into details of REMB is the [Chrome source code](https://source.chromium.org/chromium/chromium/src/+/master:third_party/webrtc/modules/rtp_rtcp/source/rtcp_packet/remb.cc).
 
-The only useful payload in the packet is the bitrate measured in bits per second.
-Notable abiguity and source of confusion is that REMB is defined as _total_ bitrate while it is common to see webrtc libraries use it to constrain video encoding bitrate only.
+The only useful payload in the packet is the bitrate, measured in bits per second.
+Notable ambiguity and a source of confusion is that REMB is defined as the _total_ bitrate, while it is common to see WebRTC libraries use it to constrain video encoding bitrate only.
 
 {{< figure src="/images/05-remb.png">}}
 ![REMB](../images/05-remb.png)
 
 ### Congestion Control
 
-Experienced WebRTC practitioners [say](https://gstconf.ubicast.tv/videos/google-transport-wide-congestion-control/) that REMB approach leaves scars, angry looks and even laughs from Google engineers.
+Experienced WebRTC practitioners [say](https://gstconf.ubicast.tv/videos/google-transport-wide-congestion-control/) that REMB's approach leaves scars, angry looks and even laughs from Google engineers.
 
 Congestion Control is the act of adjusting the media depending on the attributes of the network. If you don't have a lot of bandwidth, you need to send lower quality video.
 
 Congestion Control improves WebRTC experience by providing a more fine grained control and monitoring of network connection and conditions.
 
-
 #### TWCC
 
-Transport-Wide Congestion Control (TWCC) is an advanced congestion control specification implemented in most(?) browsers.
+Transport-Wide Congestion Control (TWCC) is an advanced congestion control specification implemented in most browsers.
 
-TWCC principle is quite simple:
+TWCC uses a quite simple principle:
 
 {{< figure src="/images/05-twcc-idea.png">}}
 ![TWCC](../images/05-twcc-idea.png)
 
-Unlike REMB, TWCC receiver doesn't try to estimate it's own incoming bitrate, it lets sender know what packets where received and when. Based on the reports sender has a very up-to-date idea of what is happening on the network.
+Unlike in REMB, a TWCC receiver doesn't try to estimate it's own incoming bitrate. It just lets the sender know which packets where received and when. Based on these reports, the sender has a very up-to-date idea of what is happening in the network.
 
-- Sender forms an RTP packet with a special TWCC header extension with packet sequence numbers
-- Receiver responds with a special RTCP feedback message that notifies sender of when and if each packet was received
+- The sender creates an RTP packet with a special TWCC header extension, containing a list of packet sequence numbers.
+- The receiver responds with a special RTCP feedback message letting the sender know if and when each packet was received.
 
-Sender keeps track of sent packets, their sequence numbers, sizes and timestamps.
-When sender receives RTCP messages from receiver, sender compares send inter-packet delays with receive delays.
-If receive delays increase it means network congestion is happenning and sender must act on it.
+The sender keeps track of sent packets, their sequence numbers, sizes and timestamps.
+When the sender receives RTCP messages from the receiver, it compares the send inter-packet delays with receive delays.
+If the receive delays increase, it means network congestion is happenning and the sender must act on it.
 
-On the diagram below median interpacket delay increase is +20msec, a clear indicator of network congestion happening.
+In the diagram below, the median interpacket delay increase is +20 msec, a clear indicator of network congestion happening.
 
 {{< figure src="/images/05-twcc.png">}}
 ![TWCC](../images/05-twcc.png)
 
 TWCC provides the raw data and an excellent view into real time network conditions:
-- almost instant packet loss statistics, not only the percent lost but exact packets that were lost
-- accurate send bitrate
-- accurate receive bitrate
-- jitter estimate
-- differences of send and receive packet delays
+- Almost instant packet loss statistics, not only the percentage lost, but the exact packets that were lost.
+- Accurate send bitrate.
+- Accurate receive bitrate.
+- A jitter estimate.
+- Differences between send and receive packet delays.
 
-To estimate receiver incoming bitrate on sender a trivial congestion control algrorithm may sum up packet sizes received and divide it by remote time elapsed.
+A trivial congestion control algrorithm to estimate the incoming bitrate on the receiver from the sender is to sum up packet sizes received, and divide it by the remote time elapsed.
 
-More sophisticated congestion control algorithms like [A Google Congestion Control Algorithm for Real-Time Communication](https://tools.ietf.org/html/draft-alvestrand-rmcat-congestion-02) or GCC for short are built on top of TWCC raw data.
+More sophisticated congestion control algorithms like [A Google Congestion Control Algorithm for Real-Time Communication](https://tools.ietf.org/html/draft-alvestrand-rmcat-congestion-02), GCC for short, are built on top of the raw TWCC data.
 GCC was proposed by Google and implemented in Chrome.
-It predicts current and future network bandwidth by using [Kalman filter](https://en.wikipedia.org/wiki/Kalman_filter).
+It predicts the current and future network bandwidth by using a [Kalman filter](https://en.wikipedia.org/wiki/Kalman_filter).
 
+There are several alternatives to GCC, for example [NADA: A Unified Congestion Control Scheme for Real-Time Media](https://tools.ietf.org/html/draft-zhu-rmcat-nada-04) and [SCReAM - Self-Clocked Rate Adaptation for Multimedia](https://tools.ietf.org/html/draft-johansson-rmcat-scream-cc-05).
 
-There are several alternatives to GCC [NADA: A Unified Congestion Control Scheme for Real-Time Media](https://tools.ietf.org/html/draft-zhu-rmcat-nada-04) and [SCReAM - Self-Clocked Rate Adaptation for Multimedia](https://tools.ietf.org/html/draft-johansson-rmcat-scream-cc-05).
+**Q**: How can I tell that TWCC is supported and enabled?
 
-
-**Q**: How can I tell that twcc is supported and enabled?
-
-**A**: Look at SDP offer/answer if you see the lines like below you have TWCC negotiated on your connection
+**A**: Look at the SDP offer/answer. If you see the lines below, you have TWCC negotiated on your connection:
 ```
 a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions
 ```
-AND
+and
 ```
 a=rtcp-fb:96 transport-cc
 ```
-
 
 ### JitterBuffer


### PR DESCRIPTION
Some sentence edits and added missing punctuation.

* wifi -> Wi-Fi
* twcc -> TWCC

I love the [history of how 1500 became the default size](https://blog.benjojo.co.uk/post/why-is-ethernet-mtu-1500), but that's way to in-depth to mention in this book.

I'm assuming "Media 101" is a WIP section, same with "Extension", "Mapping Payload Types to Codecs" and "Generic RTP Feedback"?