### PR TITLE
Fix epub generation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Build
         run: hugo --minify
 
-      - uses: docker://pandoc/latex:2.9
+      - uses: docker://pandoc/latex:2.12
         with:
           args: --output=public/docs/webrtc-for-the-curious.pdf --toc ${{ env.FILELIST }} .pandoc/metadata_en.txt
 
-      - uses: docker://pandoc/latex:2.9
+      - uses: docker://pandoc/latex:2.12
         with:
           args: --output=public/docs/webrtc-for-the-curious.epub --toc ${{ env.FILELIST }} .pandoc/metadata_en.txt
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Welcome to WebRTC for the Curious!
 
 # What is this book.
 
-Start reading the book directly from GitHub [index](content/_index.md) or at [webrtcforthecurious.com](https://webrtcforthecurious.com)
+Start reading the book directly on [GitHub](content/_index.md) or at [webrtcforthecurious.com](https://webrtcforthecurious.com)
 
 When we announced the book to social media we used the following copy
 


### PR DESCRIPTION
Bumped pandoc version to 2.12. (2.13 was just released 2 days ago, but no docker image available yet.)

Verified that this update fixes the epub issue:

<img width="1038" alt="working-epub" src="https://user-images.githubusercontent.com/50456/112105559-c9e53200-8b69-11eb-8cfd-b3da7c8d3e65.png">

Passing workflow run: https://github.com/webrtc-for-the-curious/webrtc-for-the-curious/runs/2171654221?check_suite_focus=true#logs

Generated files: https://github.com/mogren/webrtc-for-the-curious/tree/gh-pages/docs

Fixes #61
