### PR TITLE
unify the structure of the text in the order (encryption protocol)->(transmission protocol)

### DIFF
--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -80,7 +80,7 @@ We are done! You now have bi-directional and secure communication. If you have a
 
 ### Communicating with peers via RTP and SCTP
 
-We now have two WebRTC Agents with secure bi-directional communication. Let's start communicating! Again, we use two pre-existing protocols: RTP (Real-time Transport Protocol), and SCTP (Stream Control Transmission Protocol). SRTP is used to encrypt media exchanged over RTP, and SCTP is used to send DataChannel messages encrypted with DTLS.
+We now have two WebRTC Agents with secure bi-directional communication. Let's start communicating! Again, we use two pre-existing protocols: RTP (Real-time Transport Protocol), and SCTP (Stream Control Transmission Protocol). Use RTP to exchange media encrypted with SRTP, and use SCTP to send and receive DataChannel messages encrypted with DTLS.
 
 RTP is quite minimal but provides what is needed to implement real-time streaming. The important thing is that RTP gives flexibility to the developer, so they can handle latency, loss, and congestion as they please. We will discuss this further in the media chapter.
 


### PR DESCRIPTION
If it is an explanation of RTP and SCTP, I felt it would be better to unify the structure of the sentences in the order (encryption protocol)->(transmission protocol).