### PR TITLE
Fix: #138. Add Media Description syntax.

### DIFF
--- a/content.ja/docs/02-signaling.md
+++ b/content.ja/docs/02-signaling.md
@@ -49,7 +49,7 @@ WebRTC では、セッション記述プロトコルで定義されているす�
 * `o` - オリジン(Origin)、再交渉に便利なユニークな ID を含む。
 * `s` - セッション名(Session Name)、`-` と同じでなければなりません。
 * `t` - タイミング(Timing)、`0 0 0` と同じでなければなりません。
-* `m` - メディア記述(Media Description)、詳細は以下の通りです。
+* `m` - メディア記述(Media Description: `m=<media> <port> <proto> <fmt> ...`)、詳細は以下の通りです。
 * `a` - 属性(Attribute)、フリーテキストのフィールドです。これは WebRTC で最も一般的な行です。
 * `c` - 接続データ(Connection Data)、 `IN IP4 0.0.0.0` と等しくなければなりません。
 

--- a/content.zh-cn/docs/02-signaling.md
+++ b/content.zh-cn/docs/02-signaling.md
@@ -49,7 +49,7 @@ WebRTC并未使用会话描述协议定义的所有key。您当前只需要理�
 * `o` - Origin，源，包含一个唯一ID，用于重新协商
 * `s` - Session Name，会话名称，应等于`-`
 * `t` - Timing，时间，应等于`0 0`
-* `m` - Media Description，媒体描述，下面有详细说明
+* `m` - Media Description(`m=<media> <port> <proto> <fmt> ...`)，媒体描述，下面有详细说明
 * `a` - Attribute，属性，一个自由文本字段，这是WebRTC中最常见的行
 * `c` - Connection Data，连接数据，应等于`IN IP4 0.0.0.0`
 

--- a/content/docs/02-signaling.md
+++ b/content/docs/02-signaling.md
@@ -45,7 +45,7 @@ Not all key values defined by the Session Description Protocol are used by WebRT
 * `o` - Origin, contains a unique ID useful for renegotiations
 * `s` - Session Name, should be equal to `-`
 * `t` - Timing, should be equal to `0 0`
-* `m` - Media Description, described in detail below
+* `m` - Media Description(`m=<media> <port> <proto> <fmt> ...`), described in detail below
 * `a` - Attribute, a free text field. This is the most common line in WebRTC
 * `c` - Connection Data, should be equal to `IN IP4 0.0.0.0`
 


### PR DESCRIPTION
This PR fix #138. Add Media description like `m=<media> <port> <proto> <fmt> ...`.
Please take a look when you get a chance.