### PR TITLE
Minor sentence fixes and some updated formatting for chapter 2.

### DIFF
--- a/content/docs/02-signaling.md
+++ b/content/docs/02-signaling.md
@@ -15,7 +15,7 @@ Signaling messages are just text. The WebRTC agents don't care how they are tran
 WebRTC uses an existing protocol called the Session Description Protocol. Via this protocol, the two WebRTC Agents will share all the state required to establish a connection. The protocol itself is simple to read and understand.
 The complexity comes from understanding all the values that WebRTC populates it with.
 
-This protocol is not specific to WebRTC. We will learn the Session Description Protocol first without even talking about WebRTC. WebRTC only really takes advantage of a subset of the protocol so we are only going to cover what we need.
+This protocol is not specific to WebRTC. We will learn the Session Description Protocol first without even talking about WebRTC. WebRTC only really takes advantage of a subset of the protocol, so we are only going to cover what we need.
 After we understand the protocol, we will move on to its applied usage in WebRTC.
 
 ## What is the *Session Description Protocol* (SDP)?
@@ -25,11 +25,11 @@ A Session Description contains zero or more Media Descriptions. Mentally you can
 A Media Description usually maps to a single stream of media. So if you wanted to describe a call with three video streams and two audio tracks you would have five Media Descriptions.
 
 ### How to read the SDP
-Every line in a Session Description will start with a single character, this is your key. It will then be followed by an equal sign. Everything after that equal sign is the value. After the value is complete you will have a newline.
+Every line in a Session Description will start with a single character, this is your key. It will then be followed by an equal sign. Everything after that equal sign is the value. After the value is complete, you will have a newline.
 
 The Session Description Protocol defines all the keys that are valid. You can only use letters for keys as defined in the protocol. These keys all have significant meaning, which will be explained later.
 
-Take this Session Description excerpt.
+Take this Session Description excerpt:
 
 ```
 a=my-sdp-value
@@ -39,24 +39,24 @@ a=second-value
 You have two lines. Each with the key `a`. The first line has the value `my-sdp-value`, the second line has the value `second-value`.
 
 ### WebRTC only uses some SDP keys
-Not all key values defined by the Session Description Protocol are used by WebRTC. The following seven keyes are the only ones you need to understand right now:
+Not all key values defined by the Session Description Protocol are used by WebRTC. The following seven keys are the only ones you need to understand right now:
 
-* `v` - Version, should be equal to `0`
-* `o` - Origin, contains a unique ID useful for renegotiations
-* `s` - Session Name, should be equal to `-`
-* `t` - Timing, should be equal to `0 0`
-* `m` - Media Description(`m=<media> <port> <proto> <fmt> ...`), described in detail below
-* `a` - Attribute, a free text field. This is the most common line in WebRTC
-* `c` - Connection Data, should be equal to `IN IP4 0.0.0.0`
+* `v` - Version, should be equal to `0`.
+* `o` - Origin, contains a unique ID useful for renegotiations.
+* `s` - Session Name, should be equal to `-`.
+* `t` - Timing, should be equal to `0 0`.
+* `m` - Media Description (`m=<media> <port> <proto> <fmt> ...`), described in detail below.
+* `a` - Attribute, a free text field. This is the most common line in WebRTC.
+* `c` - Connection Data, should be equal to `IN IP4 0.0.0.0`.
 
 ### Media Descriptions in a Session Description
 
 A Session Description can contain an unlimited number of Media Descriptions.
 
 A Media Description definition contains a list of formats. These formats map to RTP Payload Types. The actual codec is then defined by an Attribute with the value `rtpmap` in the Media Description.
-The importance of RTP and RTP Payload Types is discussed later in the Media chapter. Each Media Description then can contain an unlimited number of attributes.
+The importance of RTP and RTP Payload Types is discussed later in the Media chapter. Each Media Description can contain an unlimited number of attributes.
 
-Take this Session Description excerpt as an example.
+Take this Session Description excerpt as an example:
 
 ```
 v=0
@@ -67,13 +67,13 @@ a=rtpmap:96 VP8/90000
 a=my-sdp-value
 ```
 
-You have two Media Descriptions, one of type audio with fmt `111` and one of type video with fmt `96`. The first Media Description has only one attribute. This attribute maps the Payload Type `111` to Opus.
-The second Media Description has two attributes. The first attribute maps the Payload Type `96` to be VP8, and the second attribute is just `my-sdp-value`
+You have two Media Descriptions, one of type audio with fmt `111` and one of type video with the format `96`. The first Media Description has only one attribute. This attribute maps the Payload Type `111` to Opus.
+The second Media Description has two attributes. The first attribute maps the Payload Type `96` to be VP8, and the second attribute is just `my-sdp-value`.
 
 ### Full Example
 
 The following brings all the concepts we have talked about together. These are all the features of the Session Description Protocol that WebRTC uses.
-If you can read this you can read any WebRTC Session Description!
+If you can read this, you can read any WebRTC Session Description!
 
 ```
 v=0
@@ -87,26 +87,26 @@ m=video 4002 RTP/AVP 96
 a=rtpmap:96 VP8/90000
 ```
 
-* `v`, `o`, `s`, `c`, `t` are defined but they do not affect the WebRTC session.
+* `v`, `o`, `s`, `c`, `t` are defined, but they do not affect the WebRTC session.
 * You have two Media Descriptions. One of type `audio` and one of type `video`.
-* Each of those has one attribute. This attribute configures details of the RTP pipeline, which is discussed in the 'Media Communication' chapter.
+* Each of those has one attribute. This attribute configures details of the RTP pipeline, which is discussed in the "Media Communication" chapter.
 
 ## How *Session Description Protocol* and WebRTC work together
 
-The next piece of the puzzle is understanding how WebRTC uses the Session Description Protocol.
+The next piece of the puzzle is understanding _how_ WebRTC uses the Session Description Protocol.
 
 ### What are Offers and Answers?
 
-WebRTC uses an offer/answer model. All this means is that one WebRTC Agent makes an 'Offer' to start a call, and the other WebRTC Agents 'Answers' if it is willing to accept what has been offered.
+WebRTC uses an offer/answer model. All this means is that one WebRTC Agent makes an "Offer" to start a call, and the other WebRTC Agents "Answers" if it is willing to accept what has been offered.
 
-This gives the answerer a chance to reject codecs, Media Descriptions. This is how two peers can understand what they are willing to exchange.
+This gives the answerer a chance to reject unsupported codecs in the Media Descriptions. This is how two peers can understand what formats they are willing to exchange.
 
 ### Transceivers are for sending and receiving
 
-Transceivers is a WebRTC specific concept that you will see in the API. What it is doing is exposing the 'Media Description' to the JavaScript API. Each Media Description becomes a Transceiver.
+Transceivers is a WebRTC specific concept that you will see in the API. What it is doing is exposing the "Media Description" to the JavaScript API. Each Media Description becomes a Transceiver.
 Every time you create a Transceiver a new Media Description is added to the local Session Description.
 
-Each Media Description in WebRTC will have a direction attribute. This allows a WebRTC Agent to declare 'I am going to send you this codec, but I am not willing to accept anything back'. There are four valid values:
+Each Media Description in WebRTC will have a direction attribute. This allows a WebRTC Agent to declare "I am going to send you this codec, but I am not willing to accept anything back". There are four valid values:
 
 * `send`
 * `recv`
@@ -121,14 +121,14 @@ This is a list of some common attributes that you will see in a Session Descript
 Bundling is an act of running multiple types of traffic over one connection. Some WebRTC implementations use a dedicated connection per media stream. Bundling should be preferred.
 
 ##### `fingerprint:sha-256`
-This is a hash of the certificate a peer is using for DTLS. After the DTLS handshake is completed you compare this to the actual certificate to confirm you are communicating with whom you expect.
+This is a hash of the certificate a peer is using for DTLS. After the DTLS handshake is completed, you compare this to the actual certificate to confirm you are communicating with whom you expect.
 
 ##### `setup:`
 This controls the DTLS Agent behavior. This determines if it runs as a client or server after ICE has connected. The possible values are:
 
-* `setup:active` - Run as DTLS Client
-* `setup:passive` - Run as DTLS Server
-* `setup:actpass` - Ask other WebRTC Agent to choose
+* `setup:active` - Run as DTLS Client.
+* `setup:passive` - Run as DTLS Server.
+* `setup:actpass` - Ask the other WebRTC Agent to choose.
 
 ##### `ice-ufrag`
 This is the user fragment value for the ICE Agent. Used for the authentication of ICE Traffic.
@@ -137,7 +137,7 @@ This is the user fragment value for the ICE Agent. Used for the authentication o
 This is the password for the ICE Agent. Used for authentication of ICE Traffic.
 
 ##### `rtpmap`
-This value is used to map a specific codec to a RTP Payload Type. Payload types are not static so every call the Offerer decides the Payload types for each codec.
+This value is used to map a specific codec to an RTP Payload Type. Payload types are not static, so for every call the offerer decides the payload types for each codec.
 
 ##### `fmtp`
 Defines additional values for one Payload Type. This is useful to communicate a specific video profile or encoder setting.
@@ -148,10 +148,10 @@ This is an ICE Candidate that comes from the ICE Agent. This is one possible add
 ##### `ssrc`
 A Synchronization Source (SSRC) defines a single media stream track.
 
-`label` is the ID for this individual stream. `mslabel` is the ID for a container that can have multiple streams inside of it.
+`label` is the ID for this individual stream. `mslabel` is the ID for a container that can have multiple streams inside it.
 
 ### Example of a WebRTC Session Description
-The following is a complete Session Description generated by a WebRTC Client.
+The following is a complete Session Description generated by a WebRTC Client:
 
 ```
 v=0
@@ -201,12 +201,12 @@ a=sendrecv
 This is what we know from this message:
 
 * We have two media sections, one audio and one video.
-* Both of them are `sendrecv` transceivers. We are getting two streams and we can send two back.
+* Both of them are `sendrecv` transceivers. We are getting two streams, and we can send two back.
 * We have ICE Candidates and Authentication details, so we can attempt to connect.
 * We have a certificate fingerprint, so we can have a secure call.
 
 ### Further Topics
-In later versions of this book, the following topics will also be addressed. If you have more questions please submit a Pull Request!
+In later versions of this book, the following topics will also be addressed:
 
 * Renegotiation
 * Simulcast


### PR DESCRIPTION
* Be more consistent about using double quotes.
* End bullet list sentences with a period.
* Use semicolon before lists and examples.
* Added a few missing commas.