### PR TITLE
onstatechange not a RTCPeerConnection method

### DIFF
--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -141,7 +141,3 @@ WebRTC uses the SSRC and looks up the associated `MediaStream` and `MediaStreamT
 #### `oniceconnectionstatechange`
 
 `oniceconnectionstatechange` is a callback that is fired that reflects the state of the ICE Agent. When you have network connectivity or when you become disconnected this is how you are notified.
-
-#### `onstatechange`
-
-`onstatechange` is a combination of ICE Agent and DTLS Agent state. You can watch this to be notified when ICE and DTLS have both completed successfully.


### PR DESCRIPTION
Hi! Just addressing issue #150 . I looked through some docs and only found onstatechange as a method of RTCSctpTransport and the underlying RTCDtlsTransport/ RTCIceTransport. So should we just delete the onstatechange from this section or specify you can use it with sctp?