### PR TITLE
Fix typo H264 -> H.264

### DIFF
--- a/content/docs/12-glossary.md
+++ b/content/docs/12-glossary.md
@@ -17,8 +17,8 @@ weight: 13
 * FEC: [Forward Error Correction](../06-media-communication/#forward-error-correction)
 * FIR: [Full INTRA-frame Request](../06-media-communication/#full-intra-frame-request-fir-and-picture-loss-indication-pli)
 * G.711: A narrowband audio codec
-* H264: Advanced video coding for generic audiovisual services
-* H265: Conformance specification for ITU-T H.265 high efficiency video coding
+* H.264: Advanced video coding for generic audiovisual services
+* H.265: Conformance specification for ITU-T H.265 high efficiency video coding
 * HEVC: High Efficiency Video Coding
 * HTTP: Hypertext Transfer Protocol
 * HTTPS: HTTP Over TLS defined in [RFC 2818](https://datatracker.ietf.org/doc/html/rfc2818)


### PR DESCRIPTION
I found a typo in the glossary.

* H264 -> H.264
* H265 -> H.265

@mogren Could you take a look when you get a chance?