### PR TITLE
Fix typo onstatechange -> onconnectionstatechange

### DIFF
--- a/content.ja/docs/01-what-why-and-how.md
+++ b/content.ja/docs/01-what-why-and-how.md
@@ -147,6 +147,6 @@ WebRTC は SSRC を使用して、関連する `MediaStream` と `MediaStreamTra
 
 `oniceconnectionstatechange` は、ICE エージェントの状態を反映して起動されるコールバックです。ネットワークに接続されたときや、切断されたときに、このように通知されます。
 
-#### `onstatechange`
+#### `onconnectionstatechange`
 
-`onstatechange` は、ICE エージェントと DTLS エージェントの状態を組み合わせたものです。これを見ることで、ICE と DTLS の両方が正常に完了したときに通知を受けることができます。
+`onconnectionstatechange` は、ICE エージェントと DTLS エージェントの状態を組み合わせたものです。これを見ることで、ICE と DTLS の両方が正常に完了したときに通知を受けることができます。

--- a/content.sv/docs/01-what-why-and-how.md
+++ b/content.sv/docs/01-what-why-and-how.md
@@ -142,6 +142,6 @@ WebRTC använder SSRC för att hitta rätt `MediaStream` och `MediaStreamTrack`,
 
 `oniceconnectionstatechange` är en återanrop som avfyras för att visa tillståndet hos ICE-agenten. När du har fått en nätverksanslutning eller när du kopplas bort så får du det här meddelandet.
 
-#### `onstatechange`
+#### `onconnectionstatechange`
 
-`onstatechange` är en kombination av ICE Agenten och DTLS Agentens tillstånd. Du kan lyssna på detta meddelande för att få veta när uppsättningen av både ICE och DTLS har slutförts.
+`onconnectionstatechange` är en kombination av ICE Agenten och DTLS Agentens tillstånd. Du kan lyssna på detta meddelande för att få veta när uppsättningen av både ICE och DTLS har slutförts.

--- a/content.zh-cn/docs/01-what-why-and-how.md
+++ b/content.zh-cn/docs/01-what-why-and-how.md
@@ -144,6 +144,6 @@ WebRTC使用SSRC并查找关联的`MediaStream`和`MediaStreamTrack`，并使用
 
 `oniceconnectionstatechange`是ICE Agent的状态变化时触发的回调。当网络连接或断开时，你将得到此通知。
 
-#### `onstatechange`
+#### `onconnectionstatechange`
 
-`onstatechange`是ICE Agent和DTLS Agent状态的组合。当ICE和DTLS都成功完成时，你将得到此通知。
+`onconnectionstatechange`是ICE Agent和DTLS Agent状态的组合。当ICE和DTLS都成功完成时，你将得到此通知。

--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -142,6 +142,6 @@ WebRTC uses the SSRC and looks up the associated `MediaStream` and `MediaStreamT
 
 `oniceconnectionstatechange` is a callback that is fired that reflects the state of the ICE Agent. When you have network connectivity or when you become disconnected this is how you are notified.
 
-#### `onstatechange`
+#### `onconnectionstatechange`
 
-`onstatechange` is a combination of ICE Agent and DTLS Agent state. You can watch this to be notified when ICE and DTLS have both completed successfully.
+`onconnectionstatechange` is a combination of ICE Agent and DTLS Agent state. You can watch this to be notified when ICE and DTLS have both completed successfully.


### PR DESCRIPTION
This PR fixes typos in `01-what-why-and-how.md` which is reported by #150.

If I understand correctly, the proposed change in #150 is correct.

* `onstatechange` does not exist in `RTCPeerConnection` interface. It exists in `DTCDtlsTransport` interface.
* `onconnectionstatechange` is fired if t ICE and DTLS state have changed.



@mogren @voluntas @Sean-Der Could you take a look when you get a chance?

https://www.w3.org/TR/webrtc/ says.

<img width="838" alt="pic1" src="https://user-images.githubusercontent.com/767650/138210751-9960509d-5b95-4364-bac3-ac1540813e76.png">
<img width="838" alt="pic2" src="https://user-images.githubusercontent.com/767650/138210778-46ad863c-7c6f-4b4b-b906-34524481439b.png">

<img width="814" alt="pic3" src="https://user-images.githubusercontent.com/767650/138210812-31fc184b-be12-4f1a-a689-87106d3628d2.png">


