### PR TITLE
Add Wireshark link.

### DIFF
--- a/content/docs/09-debugging.md
+++ b/content/docs/09-debugging.md
@@ -97,7 +97,7 @@ Common commands:
 
 #### Wireshark
 
-[Wireshark](https://www.wireshark.org) is widely-used network protocol analyzer.
+[Wireshark](https://www.wireshark.org) is a widely-used network protocol analyzer.
 
 #### webrtc-internals
 Chrome comes with a built-in WebRTC statistics page available at [chrome://webrtc-internals](chrome://webrtc-internals).


### PR DESCRIPTION
@Sean-Der, @mogren, and @voluntas Could you take a look when you get a chance?

I copied the following sentence (but remove `the world’s foremost and` part) from the [Wireshark](https://www.wireshark.org) page.

> Wireshark is the world’s foremost and widely-used network protocol analyzer.