### PR TITLE
Fix typo about `Allocation Transport` in 03-connecting TURN Lifecycle

### DIFF
--- a/content/docs/03-connecting.md
+++ b/content/docs/03-connecting.md
@@ -188,7 +188,7 @@ Allocations are at the core of TURN. An `allocation` is basically a "TURN Sessio
 
 When creating an allocation, you need to provide the following:
 * Username/Password - Creating TURN allocations require authentication.
-* Allocation Transport - The `Relayed Transport Address`, can be UDP or TCP.
+* Allocation Transport - The transport protocol between the server (`Relayed Transport Address`) and the peers, can be UDP or TCP.
 * Even-Port - You can request sequential ports for multiple allocations, not relevant for WebRTC.
 
 If the request succeeded, you get a response with the TURN Server with the following STUN Attributes in the Data section:


### PR DESCRIPTION
Is `Allocation Transport` the same as `REQUESTED-TRANSPORT`?
If it is, and according to [Traversal Using Relays around NAT](https://datatracker.ietf.org/doc/html/rfc5766) section 6.1 `Sending an Allocate Request`:

> The client MUST include a REQUESTED-TRANSPORT attribute in the
   request.  This attribute specifies the transport protocol between the
   server and the peers (note that this is NOT the transport protocol
   that appears in the 5-tuple).

then the explanation of `Allocation Transport` should be updated.