### PR TITLE
More emphasis on signaling being out-of-band

### DIFF
--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -58,7 +58,7 @@ Signaling uses an existing, plain-text protocol called SDP (Session Description 
 * The values used while connecting (`uFrag`/`uPwd`).
 * The values used while securing (certificate fingerprint).
 
-It is important to note that signaling typically happens "out-of-band", which means applications generally don't use WebRTC itself to exchange signaling messages. Any architecture suitable for sending messages can relay the SDPs between the connecting peers, and many applications will simply use their existing infrastructure (e.g. REST endpoints, WebSocket connections, or authentication proxies) to facilitate trading of SDPs between the proper clients.
+It is extremely important to note that signaling typically happens "out-of-band", which means applications generally don't use WebRTC itself to exchange signaling messages. There needs to be another communication channel between the two parties before they can initiate a WebRTC connection. What kind of channel it is is not a concern of WebRTC. Any architecture suitable for sending messages can relay the SDPs between the connecting peers, and many applications will simply use their existing infrastructure (e.g. REST endpoints, WebSocket connections, or authentication proxies) to facilitate trading of SDPs between the proper clients.
 
 ### Connecting and NAT Traversal with STUN/TURN
 

--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -58,7 +58,7 @@ Signaling uses an existing, plain-text protocol called SDP (Session Description 
 * The values used while connecting (`uFrag`/`uPwd`).
 * The values used while securing (certificate fingerprint).
 
-It is very important to note that signaling typically happens "out-of-band", which means applications generally don't use WebRTC itself to exchange signaling messages. There needs to be another communication channel between the two parties before they can initiate a WebRTC connection. What kind of channel it is is not a concern of WebRTC. Any architecture suitable for sending messages can relay the SDPs between the connecting peers, and many applications will simply use their existing infrastructure (e.g. REST endpoints, WebSocket connections, or authentication proxies) to facilitate trading of SDPs between the proper clients.
+It is very important to note that signaling typically happens "out-of-band", which means applications generally don't use WebRTC itself to exchange signaling messages. There needs to be another communication channel between the two parties before they can initiate a WebRTC connection. The kind of channel being used is not a concern of WebRTC. Any architecture suitable for sending messages can relay the SDPs between the connecting peers, and many applications will simply use their existing infrastructure (e.g. REST endpoints, WebSocket connections, or authentication proxies) to facilitate trading of SDPs between the proper clients.
 
 ### Connecting and NAT Traversal with STUN/TURN
 

--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -58,7 +58,7 @@ Signaling uses an existing, plain-text protocol called SDP (Session Description 
 * The values used while connecting (`uFrag`/`uPwd`).
 * The values used while securing (certificate fingerprint).
 
-It is extremely important to note that signaling typically happens "out-of-band", which means applications generally don't use WebRTC itself to exchange signaling messages. There needs to be another communication channel between the two parties before they can initiate a WebRTC connection. What kind of channel it is is not a concern of WebRTC. Any architecture suitable for sending messages can relay the SDPs between the connecting peers, and many applications will simply use their existing infrastructure (e.g. REST endpoints, WebSocket connections, or authentication proxies) to facilitate trading of SDPs between the proper clients.
+It is very important to note that signaling typically happens "out-of-band", which means applications generally don't use WebRTC itself to exchange signaling messages. There needs to be another communication channel between the two parties before they can initiate a WebRTC connection. What kind of channel it is is not a concern of WebRTC. Any architecture suitable for sending messages can relay the SDPs between the connecting peers, and many applications will simply use their existing infrastructure (e.g. REST endpoints, WebSocket connections, or authentication proxies) to facilitate trading of SDPs between the proper clients.
 
 ### Connecting and NAT Traversal with STUN/TURN
 


### PR DESCRIPTION
People (myself included) find this part about WebRTC very unintuitive, yet very important. So let's drive the point home.

FYI there's [the same point about it in the "Signaling" chapter](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious/blob/a91dc865c1fd5bd2f804f8f6b17eb82dc75e29de/content/docs/02-signaling.md#what-is-webrtc-signaling).

Side note: not sure about "typically" and "generally" there, maybe we should omit them as well.