### PR TITLE
Fix a couple of small typeos

### DIFF
--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -72,7 +72,7 @@ When the two agents have successfully established an ICE connection, WebRTC move
 
 ### Securing the transport layer with DTLS and SRTP
 
-Now that we have bi-directional communication (via ICE), we need to make our communication secure! This is done through two more protocols that also pre-date WebRTC; DTLS (Datagram Transport Layer Security) and SRTP (Secure Real-Time Transport Protocol). The first protocol, DTLS, is simply TLS over UDP (TLS is the cryptographic protocol used to secure communication over HTTPS). The second protocol, SRTP, is used to ensure encryption of RTP (Real-time Protocol) data packets.
+Now that we have bi-directional communication (via ICE), we need to make our communication secure! This is done through two more protocols that also pre-date WebRTC; DTLS (Datagram Transport Layer Security) and SRTP (Secure Real-Time Transport Protocol). The first protocol, DTLS, is simply TLS over UDP (TLS is the cryptographic protocol used to secure communication over HTTPS). The second protocol, SRTP, is used to ensure encryption of RTP (Real-Time Transport Protocol) data packets.
 
 First, WebRTC connects by doing a DTLS handshake over the connection established by ICE. Unlike HTTPS, WebRTC doesn't use a central authority for certificates. It simply asserts that the certificate exchanged via DTLS matches the fingerprint shared via signaling. This DTLS connection is then used for DataChannel messages.
 
@@ -133,7 +133,7 @@ Usually, after this call, you will send the offer to the remote peer, who will u
 
 ### `setRemoteDescription`
 
-`setRemoteDescription` is how we inform the local agent about the state of the remote candidates'. This is how the act of 'Signaling' is done with the JavaScript API.
+`setRemoteDescription` is how we inform the local agent about the state of the remote candidates. This is how the act of 'Signaling' is done with the JavaScript API.
 
 When `setRemoteDescription` has been called on both sides, the WebRTC agents now have enough info to start communicating Peer-To-Peer (P2P)!
 

--- a/content/docs/01-what-why-and-how.md
+++ b/content/docs/01-what-why-and-how.md
@@ -72,7 +72,7 @@ When the two agents have successfully established an ICE connection, WebRTC move
 
 ### Securing the transport layer with DTLS and SRTP
 
-Now that we have bi-directional communication (via ICE), we need to make our communication secure! This is done through two more protocols that also pre-date WebRTC; DTLS (Datagram Transport Layer Security) and SRTP (Secure Real-Time Transport Protocol). The first protocol, DTLS, is simply TLS over UDP (TLS is the cryptographic protocol used to secure communication over HTTPS). The second protocol, SRTP, is used to ensure encryption of RTP (Real-Time Transport Protocol) data packets.
+Now that we have bi-directional communication (via ICE), we need to make our communication secure! This is done through two more protocols that also pre-date WebRTC; DTLS (Datagram Transport Layer Security) and SRTP (Secure Real-Time Transport Protocol). The first protocol, DTLS, is simply TLS over UDP (TLS is the cryptographic protocol used to secure communication over HTTPS). The second protocol, SRTP, is used to ensure encryption of RTP (Real-time Transport Protocol) data packets.
 
 First, WebRTC connects by doing a DTLS handshake over the connection established by ICE. Unlike HTTPS, WebRTC doesn't use a central authority for certificates. It simply asserts that the certificate exchanged via DTLS matches the fingerprint shared via signaling. This DTLS connection is then used for DataChannel messages.
 


### PR DESCRIPTION
Add 'transport' to real time transport protocol. Remove possessive apostrophe from 'candidates'.