### PR TITLE
Add SDP explainer.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "themes/book"]
 	path = themes/book
 	url = https://github.com/alex-shpak/hugo-book
+[submodule "static/explainer"]
+	path = static/explainer
+	url = https://github.com/RKalluri1/explainer

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "themes/book"]
 	path = themes/book
 	url = https://github.com/alex-shpak/hugo-book
-[submodule "static/explainer"]
-	path = static/explainer
-	url = https://github.com/RKalluri1/explainer

--- a/content/docs/02-signaling.md
+++ b/content/docs/02-signaling.md
@@ -94,6 +94,10 @@ a=rtpmap:96 VP8/90000
 * You have two Media Descriptions. One of type `audio` and one of type `video`.
 * Each of those has one attribute. This attribute configures details of the RTP pipeline, which is discussed in the "Media Communication" chapter.
 
+### SDP Explainer
+
+[This page](/explainer/index.html) allows you to cut-n-paste your SDP and gives an explanation of its contents.
+
 ## How *Session Description Protocol* and WebRTC work together
 
 The next piece of the puzzle is understanding _how_ WebRTC uses the Session Description Protocol.

--- a/static/explainer/controller.js
+++ b/static/explainer/controller.js
@@ -1,0 +1,143 @@
+import { parseSDP, mapLineToDescription } from './parser.js';
+
+let lineHeight;
+let paddingLeft;
+let paddingTop;
+let sdpInputTimer;
+let displayedLine;
+let sdpDescriptions = {};
+let sdpOverlays = {};
+
+const explanationTemplate = {
+    "<>": "h3",
+    "text": "${heading}"
+};
+
+class SectionOverlay {
+    constructor(parent, first, last) {
+        this.overlay = document.createElement("div");
+
+        let left = paddingLeft;
+        let top = first * lineHeight + paddingTop;
+        let width = parent.clientWidth - paddingLeft;
+        let height = (last + 1) * lineHeight - top + paddingTop;
+        console.log(`lines [${first}, ${last}], top ${top}, left ${left}, width ${width}, height ${height}`)
+
+        this.overlay.style.position = "absolute"; 
+        this.overlay.style.left = `${left}px`;
+        this.overlay.style.width = `${width}px`;
+        this.overlay.style.top = `${top}px`;
+        this.overlay.style.height = `${height}px`;
+
+        this.overlay.id = `overlay-section-${first}`
+        parent.appendChild(this.overlay);
+    }
+
+    highlight() {
+        this.overlay.style.backgroundColor = '#2af';
+        this.overlay.style.opacity = '0.2';
+    }
+
+    clear() {
+        this.overlay.style.backgroundColor = 'transparent';
+        this.overlay.style.opacity = '0.0';
+    }
+};
+
+function onSDPInput() {
+    const handleInput = () => {
+        // clear current children of overlay
+        for (const [,sectionOverlay] of Object.entries(sdpOverlays)) {
+            sectionOverlay.clear();
+        }
+        let overlay = document.getElementById("overlay");
+        overlay.replaceChildren()
+
+        // Parse new SDP and populate sdpOverlays
+        try {
+            let sdpinput = document.getElementById("sdp-input");
+
+            // trim white space from both ends
+            let lines = sdpinput.value.split("\n");
+
+            // Setting the minHeight expands the textarea to show all the lines without a scrollbar.
+            sdpinput.style.minHeight = `${lines.length + (sdpinput.offsetHeight - sdpinput.clientHeight)/lineHeight}lh`;
+
+            let trimmed = lines.map((element, index, array) => { return element.trim(); });
+            sdpinput.value = trimmed.join("\n");
+
+            sdpOverlays = {};
+            sdpDescriptions = parseSDP(sdpinput.value);
+            displayedLine = null;
+
+            for (const [index, [key, description]] of Object.entries(sdpDescriptions || []).entries()) {
+                sdpOverlays[key] = new SectionOverlay(overlay, description.firstLineNumber(), description.lastLineNumber());
+            }
+        } catch (error) {
+            console.error(`error ${error}`);
+            overlay.replaceChildren();
+            sdpDescriptions = {};
+            sdpOverlays = {};
+        }
+    }
+
+    let sdpinput = document.getElementById("sdp-input");
+    if (sdpinput.value.length == 0) {
+        handleInput();
+    } else {
+        // clear previous timer
+        clearTimeout(sdpInputTimer);
+        // start new timer
+        sdpInputTimer = setTimeout(handleInput, 300);
+    }
+}
+
+function onSDPLineClick(e) {
+    let sdpInput = document.getElementById("sdp-input");
+    if (sdpInput.value.length == 0) {
+        return;
+    }
+
+    const rect = sdpInput.getBoundingClientRect();
+    let linepos = Math.floor((e.clientY - rect.top - paddingTop) / lineHeight);
+    console.log(`Y = ${e.clientY}, top = ${rect.top}, line = ${linepos}, height = ${lineHeight}`);
+    if (displayedLine != null) {
+        sdpOverlays[displayedLine].clear();
+    }
+
+    let description = mapLineToDescription(sdpDescriptions, linepos);
+    if (description != null) {
+        displayedLine = description.firstLineNumber();
+        sdpOverlays[displayedLine].highlight();
+    }
+
+    let explanation = document.getElementById("explanation");
+    explanation.innerHTML = description.explain()
+}
+
+window.addEventListener('load', () => {
+    // This function calculates the height of each line
+    // in the textarea in a browser-independent way.
+    let element = document.getElementById("sdp-input");
+    let styles = window.getComputedStyle(element);
+
+    paddingLeft = parseInt(styles.paddingLeft);
+    paddingTop = parseInt(styles.paddingTop);
+
+    const clone = element.cloneNode(false);
+    clone.innerHTML = "A\nB"; // Format for two lines to get impact of line spacing
+    clone.style.padding = "0";
+    clone.style.border = "0";
+    clone.style.visibility = "hidden";
+    clone.style.position = "absolute";
+    clone.style.minHeight = "2lh"
+
+    document.body.appendChild(clone);
+    lineHeight = clone.offsetHeight/2; // This is the line height in pixels
+    document.body.removeChild(clone);
+
+    console.debug(`lineHeight=${lineHeight}, paddingLeft=${paddingLeft}, paddingTop=${paddingTop}`);
+});
+
+window.onSDPInput = onSDPInput;
+window.onSDPLineClick = onSDPLineClick;

--- a/static/explainer/index.html
+++ b/static/explainer/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SDP Explainer</title>
+    <style>
+        body {
+            background-color:white;
+        }
+
+        #inner {
+            position: relative;
+            display: inline-block;
+        }
+
+        #outer {
+            display: flex;
+            gap: 30px;
+        }
+
+        #explanation {
+            position: sticky;
+            top: 5px;
+            border: 0px solid #ccc;
+            height: 0px;
+            white-space: pre-wrap;
+        }
+
+        #sdp-input {
+            resize:none;
+            text-align: left;
+            overflow: auto;
+            field-sizing: content;
+            width: 80ch;
+            min-height: 10lh;
+            background-color: transparent;
+            white-space: nowrap;
+            display: block;
+            padding: 10px;
+            border: 1px solid #ccc;
+        }
+
+        #overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: 1px solid #ccc; /* The frame style */
+            pointer-events: none;      /* KEY: Click through to textarea */
+            border-radius: 1px;        /* Match textarea radius if any */
+            box-sizing: border-box;    /* Ensures border doesn't add size */            
+        }
+    </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/json2html/3.3.2/json2html.min.js"></script>
+    <script type="module" src="controller.js"></script>
+</head>
+<body>
+    <h1>SDP Explainer</h1>
+    <div id="outer">
+        <div id="inner">
+            <textarea
+                id="sdp-input"
+                name="sdp"
+                placeholder="Paste your SDP here ..."
+                spellcheck="false"
+                oninput="onSDPInput()"
+                onclick="onSDPLineClick(event)"></textarea>
+            <div id="overlay"></div>
+        </div>
+        <div id="explanation"></div>
+    </div>
+</body>
+</html>

--- a/static/explainer/parser.js
+++ b/static/explainer/parser.js
@@ -1,0 +1,159 @@
+// SDP stands for Session Description Protocol, and is defined in RFC 8866.
+// RFC 8829, which established the JavaScript Session Establishment Protocol,
+// discussed the SDP keys relevant to WebRTC. RFC 9429 obsoleted RFC 8829.
+
+const NewLineRegex = /\r?\n/;
+const DescriptionLineRegex = /([^=]*)=(.*)/;
+
+class Description {
+    constructor(lines) {
+        this.lines = structuredClone(lines);
+    }
+
+    firstLineNumber() {
+        return this.lines[0][0];
+    }
+
+    lastLineNumber() {
+        return this.lines.at(-1)[0];
+    }
+
+    toString() {
+        return this.lines.map((line) => `${line[1]}=${line[2]}`).join("\n");
+    }
+
+    explain() {
+        const info = {
+            heading: "Unknown Section"
+        };
+        return JSON.stringify(info);
+    }
+};
+
+class SessionDescription extends Description {
+    constructor(lines) {
+        super(lines);
+        this.media = [];
+    }
+
+    addMedia(media) {
+        if (!(media instanceof MediaDescription)) {
+            throw new Error("Adding non-MediaDescription object");
+        }
+        this.media.push(media);
+    }
+
+    explain() {
+        let mediaitems = []
+        for (const [ , m] of Object.entries(this.media)) {
+            console.log(m);
+            console.log(Object.getOwnPropertyNames(m))
+            mediaitems.push( { type: m.mediatype } );
+        }
+
+        const info = {
+            heading: "Session Description",
+            media: {
+                subheading: `${this.media.length} media descriptions`,
+                items: mediaitems,
+            }
+        };
+
+        return JSON.stringify(info, null, 2);
+    }
+
+}
+
+class MediaDescription extends Description {
+    constructor(session, lines) {
+        super(lines);
+        this.session = session;
+
+        // From section 5.14 of RFC 8866
+        // m=<media> <port> <proto> <fmt> ...
+        let mline = /(?<media>[^ ]*) (?<port>\d*)\/?(?<numports>\d*)? (?<proto>[^ ]*) (?<fmt>.*)/
+        const results = this.lines[0][2].match(mline);
+
+        this.mediatype = results.groups.media;
+        this.port      = results.groups.port;
+        this.numports  = results.groups.numports ?? 1;
+        this.proto     = results.groups.proto;
+        this.fmt       = results.groups.fmt;
+
+        console.dir(this);
+    }
+
+    explain() {
+        const info = {
+            heading: "Media Description"
+        };
+        return JSON.stringify(info, null, 2);
+    }
+}
+
+export function parseSDP(sdp) {
+    if (sdp.length == 0) {
+        return;
+    }
+
+    let sections = [];
+    for (const [index, line] of sdp.split(NewLineRegex).entries()) {
+        if (line.length == 0) {
+            console.debug(`line ${index} empty`);
+            continue;
+        }
+
+        try {
+            let [, key, value] = line.match(DescriptionLineRegex);
+            if (key == "v") {
+                if (sections.length == 0) {
+                    sections.push([ [index, key, value] ]);
+                } else {
+                    // Only one 'v' line is allowed in a SDP
+                }
+            } else if (key == "m") {
+                sections.push([ [index, key, value] ]);
+            } else {
+                sections.at(-1).push([index, key, value]);
+            }
+        } catch (error) {
+            console.log(`error parsing line ${index}`)
+        }
+    }
+
+    let session = null;
+    let descriptions = [];
+    for (const s of (sections || [])) {
+        switch (s[0][1]) {
+            case 'v':
+                if (session != null) {
+                    throw new Error("Found multiple session descriptions");
+                }
+                session = new SessionDescription(s);
+                descriptions[session.firstLineNumber()] = session;
+                break;
+            case 'm':
+                let media = new MediaDescription(session, s);
+                session.addMedia(media);
+                descriptions[media.firstLineNumber()] = media;
+                break
+        }
+    }
+
+    console.log(`Done parsing SDP, found ${sections.length} sections`);
+
+    return descriptions;
+}
+
+export function mapLineToDescription(descriptions, line) {
+    let prevDescription;
+    for (const [key, description] of Object.entries(descriptions)) {
+        if (line == key) {
+            return description;
+        } else if (line < key) {
+            return prevDescription;
+        }
+        prevDescription = description;
+    }
+    return prevDescription;
+}


### PR DESCRIPTION
Initial version of SDP explainer. Eventually the goal is to be able to explain each section of the SDP and the selected line. For the moment, this module highlights the sections, which must begin with a `v=` or `m=` line.