### PR TITLE
Add Russian PDF and EPUB builds

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,6 +18,7 @@ jobs:
       - run: |
           echo "FILELIST=\"content/_index.md\" $(printf '"%s" ' content/docs/*.md)" >> $GITHUB_ENV
           echo "FILELIST_SV=\"content.sv/_index.md\" $(printf '"%s" ' content.sv/docs/*.md)" >> $GITHUB_ENV
+          echo "FILELIST_RU=\"content.ru/_index.md\" $(printf '"%s" ' content.ru/docs/*.md)" >> $GITHUB_ENV
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -43,6 +44,18 @@ jobs:
       - uses: docker://pandoc/latex:3.8
         with:
           args: --output=public/docs/webrtc-for-the-curious-sv.epub --resource-path=.:./content.sv:./content.sv/docs/images --toc ${{ env.FILELIST_SV }} .pandoc/metadata_sv.txt
+
+      - name: Build Russian PDF
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/data" \
+            --entrypoint /bin/sh \
+            pandoc/latex:3.8 \
+            -c "apk add --no-cache font-dejavu && pandoc --pdf-engine=xelatex --output=public/docs/webrtc-for-the-curious-ru.pdf --resource-path=.:./content.ru:./content.ru/docs/images --toc $FILELIST_RU .pandoc/metadata_pdf_ru.txt"
+
+      - uses: docker://pandoc/latex:3.8
+        with:
+          args: --output=public/docs/webrtc-for-the-curious-ru.epub --resource-path=.:./content.ru:./content.ru/docs/images --toc ${{ env.FILELIST_RU }} .pandoc/metadata_ru.txt
 
       - name: Copy images
         run: cp -r ./content/docs/images public/docs/

--- a/.pandoc/metadata_pdf_ru.txt
+++ b/.pandoc/metadata_pdf_ru.txt
@@ -1,0 +1,10 @@
+---
+title: |
+  ![](content.ru/docs/images/epub-cover.png)
+author: https://github.com/webrtc-for-the-curious/webrtc-for-the-curious
+rights: Creative Commons Zero v1.0 Universal
+language: ru-RU
+mainfont: DejaVu Serif
+sansfont: DejaVu Sans
+monofont: DejaVu Sans Mono
+...

--- a/.pandoc/metadata_ru.txt
+++ b/.pandoc/metadata_ru.txt
@@ -1,0 +1,7 @@
+---
+title: WebRTC для любопытных
+author: https://github.com/webrtc-for-the-curious/webrtc-for-the-curious
+rights: Creative Commons Zero v1.0 Universal
+language: ru-RU
+cover-image: content.ru/docs/images/epub-cover.png
+...

--- a/content.ru/_index.md
+++ b/content.ru/_index.md
@@ -37,8 +37,8 @@ WebRTC является прекрасной технологией, но она
 ## В свободном доступе и с соблюдением конфиденциальности
 
 Книга доступна на [GitHub](https://github.com/webrtc-for-the-curious/webrtc-for-the-curious) и [WebRTCforTheCurious.com](https://webrtcforthecurious.com).
-Лицензия книги дает вам свободу использовать ее как вы считаете нужным. Вы также можете скачать текущию версию книги как [ePub](https://webrtcforthecurious.com/docs/webrtc-for-the-curious.epub)
-или [PDF](https://webrtcforthecurious.com/docs/webrtc-for-the-curious.pdf) файл.
+Лицензия книги дает вам свободу использовать ее как вы считаете нужным. Вы также можете скачать текущую русскую версию книги как [ePub](https://webrtcforthecurious.com/docs/webrtc-for-the-curious-ru.epub)
+или [PDF](https://webrtcforthecurious.com/docs/webrtc-for-the-curious-ru.pdf) файл.
 
 Книга написана обычными людьми для обычных людей. Она не несет в себе конфликт интересов(vendor agnostic).
 


### PR DESCRIPTION
## Summary
- Add Pandoc metadata for Russian PDF and EPUB outputs.
- Generate Russian downloads in the GitHub Pages workflow.
- Point the Russian landing page to the new `-ru` download files.

## Test plan
- `docker run --rm --platform linux/amd64 -v "$PWD:/data" pandoc/latex:3.8 --output=/tmp/webrtc-for-the-curious-ru.epub --resource-path=.:./content.ru:./content.ru/docs/images --toc content.ru/_index.md content.ru/docs/*.md .pandoc/metadata_ru.txt`
- `docker run --rm --platform linux/amd64 -v "$PWD:/data" --entrypoint /bin/sh pandoc/latex:3.8 -c "apk add --no-cache font-dejavu && pandoc --pdf-engine=xelatex --output=/tmp/webrtc-for-the-curious-ru.pdf --resource-path=.:./content.ru:./content.ru/docs/images --toc content.ru/_index.md content.ru/docs/*.md .pandoc/metadata_pdf_ru.txt"`

Note: `hugo --minify` was not run locally because Hugo is not installed in this environment.

Made with [Cursor](https://cursor.com)