### PR TITLE
fix: upgrade CI Hugo version to v0.163.3 to resolve build failure

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.131.0'
+          hugo-version: '0.163.3'
           extended: true
 
       - name: Build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Chapters are numbered markdown files in `content/docs/`:
 
 ### Hugo Static Site Generator
 
-This project uses Hugo with the "book" theme. Hugo is required in its "extended" version (currently 0.131.0 in CI) to support advanced features.
+This project uses Hugo with the "book" theme. Hugo is required in its "extended" version (currently 0.163.3 in CI) to support advanced features.
 
 ### Multi-language Support
 


### PR DESCRIPTION
Tested locally. Required after merging #359.

• Upgraded Hugo in `gh-pages.yml` to 0.163.3 .
• Updated the documentation in `AGENTS.md`.