### PR TITLE
Fix broken images in Korean translation (content.kr)

### DIFF
--- a/content.kr/docs/01-what-why-and-how.md
+++ b/content.kr/docs/01-what-why-and-how.md
@@ -95,7 +95,7 @@ ICE는 직접 연결을 가능하게 하지만, 진정한 마법은 ‘NAT 우�
 보안 채널이 준비되면 실제 통신이 시작됩니다. 미디어는 RTP/SRTP로, 데이터는 SCTP(DataChannel)로 전송됩니다.
 코덱, 전송률 제어, 패킷 손실 대응, 지터 버퍼 등 실시간 전송 품질을 좌우하는 요소들이 여기에 포함됩니다.
 
-![WebRTC 에이전트](../images/01-webrtc-agent.png "Diagrama de Agente WebRTC")
+![WebRTC 에이전트](../../images/01-webrtc-agent.png "Diagrama de Agente WebRTC")
 
 ## WebRTC API는 어떻게 동작하나?
 

--- a/content.kr/docs/03-connecting.md
+++ b/content.kr/docs/03-connecting.md
@@ -51,7 +51,7 @@ ICE는 현실 세계 네트워크의 제약을 극복하는 데 초점을 둡니
 
 아래는 공용 인터넷으로 연결된 두 개의 서로 다른 네트워크를 보여줍니다. 각 네트워크에는 두 개의 호스트가 있습니다.
 
-![Two networks](../images/03-two-networks.png "Two networks")
+![Two networks](../../images/03-two-networks.png "Two networks")
 
 같은 네트워크 내 호스트끼리는 연결이 쉽습니다. `192.168.0.1 -> 192.168.0.2` 간 통신은 어렵지 않습니다! 외부 도움 없이도 가능합니다.
 
@@ -73,7 +73,7 @@ NAT(Network Address Translation) 매핑은 WebRTC 연결을 가능케 하는 핵
 
 릴레이나 프록시, 서버를 사용하지 않습니다. `Agent 1`과 `Agent 2`가 서로 다른 네트워크에 있지만, 트래픽은 완전히 통과합니다. 시각화하면 다음과 같습니다.
 
-![NAT mapping](../images/03-nat-mapping.png "NAT mapping")
+![NAT mapping](../../images/03-nat-mapping.png "NAT mapping")
 
 이 통신을 가능하게 하려면 NAT 매핑을 수립합니다. Agent 1이 포트 7000을 사용해 Agent 2와 WebRTC 연결을 수립하면,
 `192.168.0.1:7000` ↔ `5.0.0.1:7000` 바인딩이 생성됩니다. 이렇게 되면 Agent 2는 이 매핑으로 Agent 1에 트래픽을 보낼 수 있습니다. NAT의 동작은
@@ -158,7 +158,7 @@ TURN 서버에서 핸드셰이크 후 부여되는 `RELAYED-ADDRESS`로 생성�
 
 시각화하면 다음과 같습니다.
 
-![Connectivity checks](../images/03-connectivity-checks.png "Connectivity checks")
+![Connectivity checks](../../images/03-connectivity-checks.png "Connectivity checks")
 
 ### 후보 선택
 Controlling/Controlled 에이전트는 모든 후보쌍에 트래픽을 시도합니다. 한 에이전트가 주소 의존 매핑 뒤에 있는 경우, 이 과정에서 Peer Reflexive 후보가

--- a/content.kr/docs/05-real-time-networking.md
+++ b/content.kr/docs/05-real-time-networking.md
@@ -84,7 +84,7 @@ time=1.80 ms
 
 ### 지터 버퍼 동작
 
-![JitterBuffer](../images/05-jitterbuffer.png "JitterBuffer")
+![JitterBuffer](../../images/05-jitterbuffer.png "JitterBuffer")
 
 모든 패킷은 수신 즉시 지터 버퍼에 추가됩니다. 프레임을 재구성하기 충분한 패킷이 모이면 해당 패킷들이 버퍼에서 방출되어 디코더로 전달됩니다.
 디코더는 이를 디코드해 화면에 표시합니다. 버퍼 용량은 한정되어 있으므로, 너무 오래 머무는 패킷은 폐기됩니다.

--- a/content.kr/docs/06-media-communication.md
+++ b/content.kr/docs/06-media-communication.md
@@ -51,7 +51,7 @@ RTP에서는 보통 손실 압축을 사용합니다.
 * P-프레임: 이전 그림 대비 변경분만 포함
 * B-프레임: 이전/이후 그림을 모두 참조해 변경분만 포함
 
-![Frame types](../images/06-frame-types.png "Frame types")
+![Frame types](../../images/06-frame-types.png "Frame types")
 
 ### 비디오는 섬세하다
 비디오 압축은 강한 상태성을 갖습니다. I-프레임의 일부를 잃으면? P-프레임은 무엇을 수정해야 하는지 어떻게 알까요? 복잡해질수록 문제는 커집니다.
@@ -88,7 +88,7 @@ RTT 계산은 다음과 같습니다.
 
 `rtt = sendertime2 - sendertime1 - DLSR`
 
-![Round-trip time](../images/06-rtt.png "Round-trip time")
+![Round-trip time](../../images/06-rtt.png "Round-trip time")
 
 ## 함께 문제를 푸는 방식
 
@@ -114,12 +114,12 @@ WebRTC는 양방향으로 대역폭, RTT, 지터, 손실을 관측/전달해야 
 
 #### TMMBR/TMMBN, REMB
 수신측이 허용 비트레이트를 알려 송신자가 인코더 비트레이트를 조정합니다. 인코더 편차, 규격화 미흡 등 한계가 있어 실무에서는 세심한 튜닝이 필요합니다.
-![REMB](../images/06-remb.png "REMB")
+![REMB](../../images/06-remb.png "REMB")
 
 #### TWCC(Transport-Wide Congestion Control)
 패킷 도착 시간을 송신자에 상세히 제공해, 송신자가 직접 지연 변동/손실을 추정하고 빠르게 조정합니다. SR/RR의 송신자 중심성과 REMB의 정밀 측정을
 절충한 방식입니다.
-![TWCC](../images/06-twcc-idea.png "TWCC")
+![TWCC](../../images/06-twcc-idea.png "TWCC")
 
 송신자는 보낸 패킷의 크기/타임스탬프/시퀀스를 추적하고, 수신 리포트의 도착 간격과 비교해 혼잡을 감지합니다.
 

--- a/content.kr/docs/07-data-communication.md
+++ b/content.kr/docs/07-data-communication.md
@@ -79,7 +79,7 @@ DCEP에는 `DATA_CHANNEL_OPEN`과 `DATA_CHANNEL_ACK` 두 메시지만 있습니�
 `INIT`/`INIT ACK`로 능력/설정을 교환합니다. SCTP는 핸드셰이크 중 쿠키를 사용해 상대를 검증하고(DOS/MITM 방지), `COOKIE ECHO`/`COOKIE ACK`로
 완료합니다. 이후 DATA 교환이 시작됩니다.
 
-![Connection establishment](../images/07-connection-establishment.png "Connection establishment")
+![Connection establishment](../../images/07-connection-establishment.png "Connection establishment")
 
 ### 연결 종료 흐름
 `SHUTDOWN`으로 우아한 종료를 시작합니다. 각 측은 마지막 전송 TSN을 공유해 데이터 손실 없이 종료합니다.

--- a/content.kr/docs/08-applied-webrtc.md
+++ b/content.kr/docs/08-applied-webrtc.md
@@ -68,7 +68,7 @@ WebRTC 애플리케이션을 설계할 때 사용할 수 있는 대표적인 연
 
 연결 형태는 다음과 같습니다.
 
-![One-to-One](../images/08-one-to-one.png "One-to-One")
+![One-to-One](../../images/08-one-to-one.png "One-to-One")
 
 ### 풀 메시(Full Mesh)
 소규모 회의나 멀티플레이어 게임에 적합합니다. 모든 사용자가 서로에게 직접 연결합니다. 애플리케이션을 구축할 수 있지만 단점도 있습니다.
@@ -78,7 +78,7 @@ WebRTC 애플리케이션을 설계할 때 사용할 수 있는 대표적인 연
 
 이런 이유로 풀 메시 토폴로지는 소규모 그룹에 적합하며, 더 큰 규모에는 클라이언트/서버 토폴로지가 좋습니다.
 
-![Full mesh](../images/08-full-mesh.png "Full mesh")
+![Full mesh](../../images/08-full-mesh.png "Full mesh")
 
 ### 하이브리드 메시
 풀 메시의 문제를 일부 완화하는 대안입니다. 모든 사용자 사이에 직접 연결을 만들지 않고, 네트워크 내 다른 피어를 통해 미디어를 릴레이합니다.
@@ -86,7 +86,7 @@ WebRTC 애플리케이션을 설계할 때 사용할 수 있는 대표적인 연
 
 다만 단점도 있습니다. 원본 발행자는 자신의 비디오가 누구에게 전달되는지, 성공적으로 도착했는지 알기 어렵습니다. 또한 홉이 늘어날수록 지연이 증가합니다.
 
-![Hybrid mesh](../images/08-hybrid-mesh.png "Hybrid mesh")
+![Hybrid mesh](../../images/08-hybrid-mesh.png "Hybrid mesh")
 
 ### SFU(Selective Forwarding Unit)
 SFU는 풀 메시의 문제를 전혀 다른 방식으로 해결합니다. P2P 대신 클라이언트/서버 토폴로지를 구현합니다. 각 WebRTC 피어는 SFU에 연결해
@@ -98,11 +98,11 @@ SFU는 풀 메시의 문제를 전혀 다른 방식으로 해결합니다. P2P �
 간단한 SFU는 주말 동안에도 만들 수 있지만, 모든 유형의 클라이언트를 잘 다루는 ‘좋은’ SFU를 만드는 일은 끝이 없습니다. 혼잡 제어, 오류 정정,
 성능 튜닝은 지속적인 과제입니다.
 
-![Selective Forwarding Unit](../images/08-sfu.png "Selective Forwarding Unit")
+![Selective Forwarding Unit](../../images/08-sfu.png "Selective Forwarding Unit")
 
 ### MCU
 MCU(Multi-point Conferencing Unit)는 SFU처럼 클라이언트/서버 토폴로지이지만, 출력 스트림을 합성합니다. 개별 스트림을 그대로 배포하는 대신
 하나의 피드로 다시 인코딩해 전달합니다.
 
-![Multi-point Conferencing Unit](../images/08-mcu.png "Multi-point Conferencing Unit")
+![Multi-point Conferencing Unit](../../images/08-mcu.png "Multi-point Conferencing Unit")
 

--- a/content.kr/docs/09-debugging.md
+++ b/content.kr/docs/09-debugging.md
@@ -70,13 +70,13 @@ Chrome의 통계 페이지: `chrome://webrtc-internals`
 - 휴대폰으로 시계와 수신 화면을 동시에 찍습니다.
 - 두 시각의 차이를 구합니다.
 
-![DIY Latency](../images/09-diy-latency.png "DIY Latency Measurement").
-![DIY Latency Example](../images/09-diy-latency-happen-observe.png "DIY Latency Measurement Example")
+![DIY Latency](../../images/09-diy-latency.png "DIY Latency Measurement").
+![DIY Latency Example](../../images/09-diy-latency-happen-observe.png "DIY Latency Measurement Example")
 
 ### 자동 측정(호환 방식)
 NTP 스타일로 DataChannel을 이용해 송신자/수신자 단조 시계를 동기화하고, 비디오 트랙 시간과 대조해 지연을 추정합니다.
 
-![NTP Style Latency Measurement](../images/09-ntp-latency.png "NTP Style Latency Measurement")
+![NTP Style Latency Measurement](../../images/09-ntp-latency.png "NTP Style Latency Measurement")
 
 핵심 개념:
 


### PR DESCRIPTION
## Problem

Images in the Korean translation (`content.kr`) are broken on [webrtcforthecurious.com/ko](https://webrtcforthecurious.com/ko/). All image references return 404.

**Example:** [연결 (Connecting) page](https://webrtcforthecurious.com/ko/docs/03-connecting/)

| Image URL | Status |
|---|---|
| `/ko/docs/images/03-two-networks.png` (current) | ❌ 404 |
| `/ko/images/03-two-networks.png` (correct) | ✅ 200 |

## Root Cause

The Korean markdown files reference images with `../images/` (one level up). Hugo resolves this relative to the `docs/` page bundle, producing `/ko/docs/images/...` — but the images live in `content.kr/images/`, which maps to `/ko/images/...`.

The correct path is `../../images/` (two levels up from `docs/`), which is already used by the Spanish (`content.es`), Chinese (`content.zh-cn`), and most Japanese (`content.ja`) translations.

| Translation | Pattern | Status |
|---|---|---|
| `content.es` | `../../images/` | ✅ Works |
| `content.zh-cn` | `../../images/` | ✅ Works |
| `content.ja` | `../../images/` | ✅ Works |
| **`content.kr`** | **`../images/`** | **❌ Broken** |
| `content.fr` | `../images/` | ❌ Broken |
| `content.ru` | `../images/` | ❌ Broken |
| `content.id` | `../images/` | ❌ Broken |
| `content.fa` | `../images/` | ❌ Broken |
| `content.tr` | `../images/` | ❌ Broken |

## Fix

Changed all `../images/` references to `../../images/` in `content.kr/docs/`.

- **7 files** changed
- **18 image references** fixed

## Verification

Built the site locally with Hugo (`hugo --minity`) and verified every image renders:

**1. Hugo build succeeds** — no errors, KO section builds 23 pages + 0 non-page files (images served from `/ko/images/`)

**2. Generated HTML uses correct paths:**
```html
<img src=../../images/03-two-networks.png alt="Two networks" title="Two networks">
```

**3. All 18 images across 7 pages return HTTP 200** (tested via local server):

| Page | Images | Status |
|---|---|---|
| `01-what-why-and-how` | 1 | ✅ 200 |
| `03-connecting` | 3 | ✅ 200 |
| `05-real-time-networking` | 1 | ✅ 200 |
| `06-media-communication` | 4 | ✅ 200 |
| `07-data-communication` | 1 | ✅ 200 |
| `08-applied-webrtc` | 5 | ✅ 200 |
| `09-debugging` | 3 | ✅ 200 |

**4. Browser rendering confirmed** — all images load with non-zero `naturalWidth`, no broken images.

## Note

The same issue affects `content.fr`, `content.ru`, `content.id`, `content.fa`, and `content.tr`. I scoped this PR to Korean only to keep it focused, but happy to extend it to the other translations if maintainers prefer.